### PR TITLE
Enable canvas pan and zoom

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,8 @@
     border: 1px solid var(--control-border);
     width: 640px;
     height: 480px;
+    transform-origin: 0 0;
+    overflow: hidden;
 }
 #motif {
     position: absolute;
@@ -75,6 +77,12 @@ const clearBtn = document.getElementById('clearBtn');
 const container = document.getElementById('canvasContainer');
 let drawing = false;
 let strokes = 0;
+let scale = 1;
+let panX = 0;
+let panY = 0;
+let panning = false;
+let startPanX = 0;
+let startPanY = 0;
 
 function setCanvasSize(width, height) {
     container.style.width = width + 'px';
@@ -87,9 +95,23 @@ function resizeCanvas() {
     if (motif.style.display === 'block') {
         setCanvasSize(motif.clientWidth, motif.clientHeight);
     }
+    updateTransform();
+}
+
+function updateTransform() {
+    container.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+}
+
+function getCanvasCoords(e) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: (e.clientX - rect.left) * (canvas.width / rect.width),
+        y: (e.clientY - rect.top) * (canvas.height / rect.height)
+    };
 }
 
 setCanvasSize(640, 480);
+updateTransform();
 
 imageLoader.addEventListener('change', function(e) {
     const reader = new FileReader();
@@ -106,19 +128,73 @@ imageLoader.addEventListener('change', function(e) {
 window.addEventListener('resize', resizeCanvas);
 
 canvas.addEventListener('pointerdown', e => {
-    drawing = true;
-    canvas.setPointerCapture(e.pointerId);
-    ctx.strokeStyle = penColor.value;
-    ctx.lineWidth = penWidth.value;
-    ctx.lineCap = 'round';
-    ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
-    motif.style.visibility = 'hidden';
+    if (e.button === 0) {
+        drawing = true;
+        canvas.setPointerCapture(e.pointerId);
+        ctx.strokeStyle = penColor.value;
+        ctx.lineWidth = penWidth.value;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        const pos = getCanvasCoords(e);
+        ctx.moveTo(pos.x, pos.y);
+        motif.style.visibility = 'hidden';
+    }
+});
+
+container.addEventListener('pointerdown', e => {
+    if (e.button === 1) {
+        e.preventDefault();
+        panning = true;
+        container.setPointerCapture(e.pointerId);
+        startPanX = e.clientX - panX;
+        startPanY = e.clientY - panY;
+    }
+});
+
+container.addEventListener('pointermove', e => {
+    if (panning) {
+        panX = e.clientX - startPanX;
+        panY = e.clientY - startPanY;
+        updateTransform();
+    }
+});
+
+container.addEventListener('pointerup', e => {
+    if (panning && e.button === 1) {
+        panning = false;
+        container.releasePointerCapture(e.pointerId);
+    }
+});
+
+container.addEventListener('pointerleave', e => {
+    if (panning) {
+        panning = false;
+        container.releasePointerCapture(e.pointerId);
+    }
+});
+
+container.addEventListener('wheel', e => {
+    e.preventDefault();
+    const zoomFactor = 1.1;
+    const rect = container.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const oldScale = scale;
+    if (e.deltaY < 0) {
+        scale *= zoomFactor;
+    } else {
+        scale /= zoomFactor;
+    }
+    scale = Math.min(Math.max(scale, 0.1), 10);
+    panX = offsetX - (offsetX - panX) * (scale / oldScale);
+    panY = offsetY - (offsetY - panY) * (scale / oldScale);
+    updateTransform();
 });
 
 canvas.addEventListener('pointermove', e => {
     if (!drawing) return;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const pos = getCanvasCoords(e);
+    ctx.lineTo(pos.x, pos.y);
     ctx.stroke();
 });
 

--- a/script.js
+++ b/script.js
@@ -8,6 +8,12 @@ const clearBtn = document.getElementById('clearBtn');
 const container = document.getElementById('canvasContainer');
 let drawing = false;
 let strokes = 0;
+let scale = 1;
+let panX = 0;
+let panY = 0;
+let panning = false;
+let startPanX = 0;
+let startPanY = 0;
 
 function setCanvasSize(width, height) {
     container.style.width = width + 'px';
@@ -20,10 +26,12 @@ function resizeCanvas() {
     if (motif.style.display === 'block') {
         setCanvasSize(motif.clientWidth, motif.clientHeight);
     }
+    updateTransform();
 }
 
 // initialize default canvas size
 setCanvasSize(640, 480);
+updateTransform();
 
 imageLoader.addEventListener('change', function(e) {
     const reader = new FileReader();
@@ -39,20 +47,86 @@ imageLoader.addEventListener('change', function(e) {
 
 window.addEventListener('resize', resizeCanvas);
 
+function updateTransform() {
+    container.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+}
+
+function getCanvasCoords(e) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: (e.clientX - rect.left) * (canvas.width / rect.width),
+        y: (e.clientY - rect.top) * (canvas.height / rect.height)
+    };
+}
+
 canvas.addEventListener('pointerdown', e => {
-    drawing = true;
-    canvas.setPointerCapture(e.pointerId);
-    ctx.strokeStyle = penColor.value;
-    ctx.lineWidth = penWidth.value;
-    ctx.lineCap = 'round';
-    ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
-    motif.style.visibility = 'hidden';
+    if (e.button === 0) {
+        drawing = true;
+        canvas.setPointerCapture(e.pointerId);
+        ctx.strokeStyle = penColor.value;
+        ctx.lineWidth = penWidth.value;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        const pos = getCanvasCoords(e);
+        ctx.moveTo(pos.x, pos.y);
+        motif.style.visibility = 'hidden';
+    }
+});
+
+container.addEventListener('pointerdown', e => {
+    if (e.button === 1) {
+        e.preventDefault();
+        panning = true;
+        container.setPointerCapture(e.pointerId);
+        startPanX = e.clientX - panX;
+        startPanY = e.clientY - panY;
+    }
+});
+
+container.addEventListener('pointermove', e => {
+    if (panning) {
+        panX = e.clientX - startPanX;
+        panY = e.clientY - startPanY;
+        updateTransform();
+    }
+});
+
+container.addEventListener('pointerup', e => {
+    if (panning && e.button === 1) {
+        panning = false;
+        container.releasePointerCapture(e.pointerId);
+    }
+});
+
+container.addEventListener('pointerleave', e => {
+    if (panning) {
+        panning = false;
+        container.releasePointerCapture(e.pointerId);
+    }
+});
+
+container.addEventListener('wheel', e => {
+    e.preventDefault();
+    const zoomFactor = 1.1;
+    const rect = container.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const oldScale = scale;
+    if (e.deltaY < 0) {
+        scale *= zoomFactor;
+    } else {
+        scale /= zoomFactor;
+    }
+    scale = Math.min(Math.max(scale, 0.1), 10);
+    panX = offsetX - (offsetX - panX) * (scale / oldScale);
+    panY = offsetY - (offsetY - panY) * (scale / oldScale);
+    updateTransform();
 });
 
 canvas.addEventListener('pointermove', e => {
     if (!drawing) return;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const pos = getCanvasCoords(e);
+    ctx.lineTo(pos.x, pos.y);
     ctx.stroke();
 });
 

--- a/style.css
+++ b/style.css
@@ -34,6 +34,8 @@ h1 {
     border: 1px solid #ccc;
     width: 640px;
     height: 480px;
+    transform-origin: 0 0;
+    overflow: hidden;
 }
 
 #motif {


### PR DESCRIPTION
## Summary
- add pan and zoom handling with middle mouse and wheel
- hide motif while drawing and show it after drawing
- keep drawing consistent when the canvas is transformed

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6854cf28d1248322b4012002a0188e56