### PR TITLE
Implement undo/redo and export options

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,11 @@ canvas {
   <label>画像アップロード <input type="file" id="imageLoader" accept="image/*" /></label>
   <label>ペン色 <input type="color" id="penColor" value="#000000"></label>
   <label>ペン太さ <input type="range" id="penWidth" min="1" max="20" value="3"></label>
+  <label><input type="checkbox" id="antialiasToggle" checked> アンチエイリアス</label>
+  <label><input type="checkbox" id="stabilizeToggle"> 手振れ補正</label>
+  <button id="undoBtn">元に戻す</button>
+  <button id="redoBtn">やり直し</button>
+  <button id="saveBtn">PNG保存</button>
   <button id="clearBtn">クリア</button>
 </div>
 <div id="canvasContainer">
@@ -74,6 +79,11 @@ const ctx = canvas.getContext('2d');
 const penColor = document.getElementById('penColor');
 const penWidth = document.getElementById('penWidth');
 const clearBtn = document.getElementById('clearBtn');
+const undoBtn = document.getElementById('undoBtn');
+const redoBtn = document.getElementById('redoBtn');
+const saveBtn = document.getElementById('saveBtn');
+const antialiasToggle = document.getElementById('antialiasToggle');
+const stabilizeToggle = document.getElementById('stabilizeToggle');
 const container = document.getElementById('canvasContainer');
 let drawing = false;
 let strokes = 0;
@@ -83,6 +93,27 @@ let panY = 0;
 let panning = false;
 let startPanX = 0;
 let startPanY = 0;
+let antialias = true;
+let stabilize = false;
+let lastPos = null;
+
+let history = [];
+let historyIndex = -1;
+
+function saveHistory() {
+    history = history.slice(0, historyIndex + 1);
+    history.push(canvas.toDataURL());
+    historyIndex = history.length - 1;
+}
+
+function restoreHistory(index) {
+    const img = new Image();
+    img.onload = () => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, 0, 0);
+    };
+    img.src = history[index];
+}
 
 function setCanvasSize(width, height) {
     container.style.width = width + 'px';
@@ -112,6 +143,7 @@ function getCanvasCoords(e) {
 
 setCanvasSize(640, 480);
 updateTransform();
+saveHistory();
 
 imageLoader.addEventListener('change', function(e) {
     const reader = new FileReader();
@@ -134,8 +166,11 @@ canvas.addEventListener('pointerdown', e => {
         ctx.strokeStyle = penColor.value;
         ctx.lineWidth = penWidth.value;
         ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.imageSmoothingEnabled = antialias;
         ctx.beginPath();
         const pos = getCanvasCoords(e);
+        lastPos = pos;
         ctx.moveTo(pos.x, pos.y);
         motif.style.visibility = 'hidden';
     }
@@ -194,13 +229,24 @@ container.addEventListener('wheel', e => {
 canvas.addEventListener('pointermove', e => {
     if (!drawing) return;
     const pos = getCanvasCoords(e);
-    ctx.lineTo(pos.x, pos.y);
+    let drawPos = pos;
+    if (stabilize && lastPos) {
+        lastPos = {
+            x: lastPos.x * 0.75 + pos.x * 0.25,
+            y: lastPos.y * 0.75 + pos.y * 0.25
+        };
+        drawPos = lastPos;
+    }
+    ctx.lineTo(drawPos.x, drawPos.y);
     ctx.stroke();
 });
 
 function endDraw() {
-    drawing = false;
-    motif.style.visibility = 'visible';
+    if (drawing) {
+        drawing = false;
+        motif.style.visibility = 'visible';
+        saveHistory();
+    }
 }
 
 canvas.addEventListener('pointerup', e => {
@@ -212,6 +258,44 @@ canvas.addEventListener('pointerleave', endDraw);
 clearBtn.addEventListener('click', () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     strokes = 0;
+    saveHistory();
+});
+
+undoBtn.addEventListener('click', () => {
+    if (historyIndex > 0) {
+        historyIndex--;
+        restoreHistory(historyIndex);
+    }
+});
+
+redoBtn.addEventListener('click', () => {
+    if (historyIndex < history.length - 1) {
+        historyIndex++;
+        restoreHistory(historyIndex);
+    }
+});
+
+saveBtn.addEventListener('click', () => {
+    const exportCanvas = document.createElement('canvas');
+    exportCanvas.width = canvas.width;
+    exportCanvas.height = canvas.height;
+    const exportCtx = exportCanvas.getContext('2d');
+    if (motif.src) {
+        exportCtx.drawImage(motif, 0, 0, canvas.width, canvas.height);
+    }
+    exportCtx.drawImage(canvas, 0, 0);
+    const link = document.createElement('a');
+    link.href = exportCanvas.toDataURL('image/png');
+    link.download = 'drawing.png';
+    link.click();
+});
+
+antialiasToggle.addEventListener('change', e => {
+    antialias = e.target.checked;
+});
+
+stabilizeToggle.addEventListener('change', e => {
+    stabilize = e.target.checked;
 });
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
         <label>Motif Image: <input type="file" id="imageLoader" accept="image/*"></label>
         <label>Pen Color: <input type="color" id="penColor" value="#000000"></label>
         <label>Pen Width: <input type="range" id="penWidth" min="1" max="20" value="3"></label>
+        <label><input type="checkbox" id="antialiasToggle" checked> Antialias</label>
+        <label><input type="checkbox" id="stabilizeToggle"> Stabilize</label>
+        <button id="undoBtn">Undo</button>
+        <button id="redoBtn">Redo</button>
+        <button id="saveBtn">Save PNG</button>
         <button id="clearBtn">Clear</button>
     </div>
     <div id="canvasContainer">


### PR DESCRIPTION
## Summary
- add toggle controls for antialiasing and stroke stabilization
- implement undo/redo history and PNG export
- expose the new controls in docs version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854e358cddc8322a248d681f33a2a72