### PR TITLE
Add shortcuts and stabilizer slider

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,8 @@
     padding: 8px;
     background: var(--control-bg);
     border-bottom: 1px solid var(--control-border);
+    position: relative;
+    z-index: 10;
  }
  #controls > * {
     margin: 4px;
@@ -35,6 +37,7 @@
     height: 480px;
     transform-origin: 0 0;
     overflow: hidden;
+    z-index: 1;
 }
 #motif {
     position: absolute;
@@ -61,11 +64,12 @@ canvas {
   <label>ペン色 <input type="color" id="penColor" value="#000000"></label>
   <label>ペン太さ <input type="range" id="penWidth" min="1" max="20" value="3"></label>
   <label><input type="checkbox" id="antialiasToggle" checked> アンチエイリアス</label>
-  <label><input type="checkbox" id="stabilizeToggle"> 手振れ補正</label>
+  <label>手振れ補正 <input type="range" id="stabilizeRange" min="0" max="0.9" step="0.1" value="0"></label>
   <button id="undoBtn">元に戻す</button>
   <button id="redoBtn">やり直し</button>
   <button id="saveBtn">PNG保存</button>
   <button id="clearBtn">クリア</button>
+  <button id="centerBtn">中央表示</button>
 </div>
 <div id="canvasContainer">
   <img id="motif" style="display:none;" />
@@ -83,7 +87,8 @@ const undoBtn = document.getElementById('undoBtn');
 const redoBtn = document.getElementById('redoBtn');
 const saveBtn = document.getElementById('saveBtn');
 const antialiasToggle = document.getElementById('antialiasToggle');
-const stabilizeToggle = document.getElementById('stabilizeToggle');
+const stabilizeRange = document.getElementById('stabilizeRange');
+const centerBtn = document.getElementById('centerBtn');
 const container = document.getElementById('canvasContainer');
 let drawing = false;
 let strokes = 0;
@@ -94,7 +99,7 @@ let panning = false;
 let startPanX = 0;
 let startPanY = 0;
 let antialias = true;
-let stabilize = false;
+let stabilizeAmount = 0;
 let lastPos = null;
 
 let history = [];
@@ -170,8 +175,12 @@ canvas.addEventListener('pointerdown', e => {
         ctx.imageSmoothingEnabled = antialias;
         ctx.beginPath();
         const pos = getCanvasCoords(e);
-        lastPos = pos;
-        ctx.moveTo(pos.x, pos.y);
+        let startPos = pos;
+        if (!antialias) {
+            startPos = { x: Math.round(pos.x) + 0.5, y: Math.round(pos.y) + 0.5 };
+        }
+        lastPos = startPos;
+        ctx.moveTo(startPos.x, startPos.y);
         motif.style.visibility = 'hidden';
     }
 });
@@ -230,12 +239,15 @@ canvas.addEventListener('pointermove', e => {
     if (!drawing) return;
     const pos = getCanvasCoords(e);
     let drawPos = pos;
-    if (stabilize && lastPos) {
+    if (stabilizeAmount > 0 && lastPos) {
         lastPos = {
-            x: lastPos.x * 0.75 + pos.x * 0.25,
-            y: lastPos.y * 0.75 + pos.y * 0.25
+            x: lastPos.x * stabilizeAmount + pos.x * (1 - stabilizeAmount),
+            y: lastPos.y * stabilizeAmount + pos.y * (1 - stabilizeAmount)
         };
         drawPos = lastPos;
+    }
+    if (!antialias) {
+        drawPos = { x: Math.round(drawPos.x) + 0.5, y: Math.round(drawPos.y) + 0.5 };
     }
     ctx.lineTo(drawPos.x, drawPos.y);
     ctx.stroke();
@@ -294,8 +306,27 @@ antialiasToggle.addEventListener('change', e => {
     antialias = e.target.checked;
 });
 
-stabilizeToggle.addEventListener('change', e => {
-    stabilize = e.target.checked;
+stabilizeRange.addEventListener('input', e => {
+    stabilizeAmount = parseFloat(e.target.value);
+});
+
+centerBtn.addEventListener('click', () => {
+    const rect = container.getBoundingClientRect();
+    panX += window.innerWidth / 2 - (rect.left + rect.width / 2);
+    panY += window.innerHeight / 2 - (rect.top + rect.height / 2);
+    updateTransform();
+});
+
+document.addEventListener('keydown', e => {
+    if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        undoBtn.click();
+    } else if ((e.ctrlKey || e.metaKey) && ((e.shiftKey && e.key.toLowerCase() === 'z') || e.key.toLowerCase() === 'y')) {
+        e.preventDefault();
+        redoBtn.click();
+    } else if (e.key === 'Delete') {
+        clearBtn.click();
+    }
 });
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -12,11 +12,12 @@
         <label>Pen Color: <input type="color" id="penColor" value="#000000"></label>
         <label>Pen Width: <input type="range" id="penWidth" min="1" max="20" value="3"></label>
         <label><input type="checkbox" id="antialiasToggle" checked> Antialias</label>
-        <label><input type="checkbox" id="stabilizeToggle"> Stabilize</label>
+        <label>Stabilize <input type="range" id="stabilizeRange" min="0" max="0.9" step="0.1" value="0"></label>
         <button id="undoBtn">Undo</button>
         <button id="redoBtn">Redo</button>
         <button id="saveBtn">Save PNG</button>
         <button id="clearBtn">Clear</button>
+        <button id="centerBtn">Center</button>
     </div>
     <div id="canvasContainer">
         <img id="motif" style="display:none;" />

--- a/style.css
+++ b/style.css
@@ -27,6 +27,8 @@ h1 {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
+    position: relative;
+    z-index: 10;
 }
 
 #canvasContainer {
@@ -36,6 +38,7 @@ h1 {
     height: 480px;
     transform-origin: 0 0;
     overflow: hidden;
+    z-index: 1;
 }
 
 #motif {


### PR DESCRIPTION
## Summary
- fix layering so controls stay above canvas
- add stabilize slider and canvas center button
- implement keyboard shortcuts for undo/redo/clear
- adjust antialias behavior and pan centering logic
- update docs with new UI and behaviors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854e7cc1d788322b7bf1491ba2d7c71