### PR TITLE
Add stroke playback feature

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,12 @@ canvas {
   <button id="saveBtn">PNG保存</button>
   <button id="clearBtn">クリア</button>
   <button id="centerBtn">中央表示</button>
+  <label>JSONインポート <input type="file" id="importJson" accept=".json" /></label>
+  <button id="exportJsonBtn">JSONエクスポート</button>
+  <div id="playbackControls">
+    <button id="playBtn">再生</button>
+    <input type="range" id="playbackRange" min="0" value="0" step="1">
+  </div>
 </div>
 <div id="canvasContainer">
   <img id="motif" style="display:none;" />
@@ -89,6 +95,11 @@ const saveBtn = document.getElementById('saveBtn');
 const antialiasToggle = document.getElementById('antialiasToggle');
 const stabilizeRange = document.getElementById('stabilizeRange');
 const centerBtn = document.getElementById('centerBtn');
+const importJson = document.getElementById('importJson');
+const exportJsonBtn = document.getElementById('exportJsonBtn');
+const playBtn = document.getElementById('playBtn');
+const playbackRange = document.getElementById('playbackRange');
+const GRID_SIZE = 16;
 const container = document.getElementById('canvasContainer');
 let drawing = false;
 let strokes = 0;
@@ -105,6 +116,12 @@ let lastPos = null;
 let history = [];
 let historyIndex = -1;
 
+let recordedStrokes = [];
+let currentStroke = [];
+let playbackStrokes = [];
+let playTimer = null;
+let lastCell = null;
+
 function saveHistory() {
     history = history.slice(0, historyIndex + 1);
     history.push(canvas.toDataURL());
@@ -118,6 +135,37 @@ function restoreHistory(index) {
         ctx.drawImage(img, 0, 0);
     };
     img.src = history[index];
+}
+
+function toCell(pos) {
+  return { x: Math.floor(pos.x / GRID_SIZE), y: Math.floor(pos.y / GRID_SIZE) };
+}
+
+function cellToPos(cell) {
+  return { x: cell.x * GRID_SIZE + GRID_SIZE / 2, y: cell.y * GRID_SIZE + GRID_SIZE / 2 };
+}
+
+function drawStroke(cells) {
+  if (!cells.length) return;
+  const pts = cells.map(cellToPos);
+  ctx.beginPath();
+  ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 0; i < pts.length - 1; i++) {
+    const c = pts[i];
+    const n = pts[i + 1];
+    const mx = (c.x + n.x) / 2;
+    const my = (c.y + n.y) / 2;
+    ctx.quadraticCurveTo(c.x, c.y, mx, my);
+  }
+  ctx.lineTo(pts[pts.length - 1].x, pts[pts.length - 1].y);
+  ctx.stroke();
+}
+
+function renderFrame(n) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (let i = 0; i < n; i++) {
+    drawStroke(playbackStrokes[i]);
+  }
 }
 
 function setCanvasSize(width, height) {
@@ -182,6 +230,11 @@ canvas.addEventListener('pointerdown', e => {
         lastPos = startPos;
         ctx.moveTo(startPos.x, startPos.y);
         motif.style.visibility = 'hidden';
+
+        currentStroke = [];
+        const cell = toCell(startPos);
+        currentStroke.push(cell);
+        lastCell = cell;
     }
 });
 
@@ -246,6 +299,11 @@ canvas.addEventListener('pointermove', e => {
         };
         drawPos = lastPos;
     }
+    const cell = toCell(pos);
+    if (!lastCell || cell.x !== lastCell.x || cell.y !== lastCell.y) {
+        currentStroke.push(cell);
+        lastCell = cell;
+    }
     if (!antialias) {
         drawPos = { x: Math.round(drawPos.x) + 0.5, y: Math.round(drawPos.y) + 0.5 };
     }
@@ -258,6 +316,14 @@ function endDraw() {
         drawing = false;
         motif.style.visibility = 'visible';
         saveHistory();
+        if (currentStroke.length) {
+            recordedStrokes.push(currentStroke);
+            playbackStrokes = recordedStrokes.slice();
+            playbackRange.max = playbackStrokes.length;
+            playbackRange.value = playbackRange.max;
+        }
+        currentStroke = [];
+        lastCell = null;
     }
 }
 
@@ -271,6 +337,10 @@ clearBtn.addEventListener('click', () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     strokes = 0;
     saveHistory();
+    recordedStrokes = [];
+    playbackStrokes = [];
+    playbackRange.max = 0;
+    playbackRange.value = 0;
 });
 
 undoBtn.addEventListener('click', () => {
@@ -315,6 +385,66 @@ centerBtn.addEventListener('click', () => {
     panX += window.innerWidth / 2 - (rect.left + rect.width / 2);
     panY += window.innerHeight / 2 - (rect.top + rect.height / 2);
     updateTransform();
+});
+
+function startPlayback() {
+  if (playTimer || !playbackStrokes.length) return;
+  playBtn.textContent = '一時停止';
+  playTimer = setInterval(() => {
+    let val = parseInt(playbackRange.value);
+    if (val >= playbackStrokes.length) {
+      stopPlayback();
+      return;
+    }
+    val++;
+    playbackRange.value = val;
+    renderFrame(val);
+  }, 300);
+}
+
+function stopPlayback() {
+  if (!playTimer) return;
+  clearInterval(playTimer);
+  playTimer = null;
+  playBtn.textContent = '再生';
+}
+
+playBtn.addEventListener('click', () => {
+  if (playTimer) {
+    stopPlayback();
+  } else {
+    startPlayback();
+  }
+});
+
+playbackRange.addEventListener('input', e => {
+  stopPlayback();
+  renderFrame(parseInt(e.target.value));
+});
+
+exportJsonBtn.addEventListener('click', () => {
+  const data = { gridSize: GRID_SIZE, strokes: recordedStrokes };
+  const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'strokes.json';
+  link.click();
+  URL.revokeObjectURL(url);
+});
+
+importJson.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    const data = JSON.parse(ev.target.result);
+    playbackStrokes = data.strokes || [];
+    playbackRange.max = playbackStrokes.length;
+    playbackRange.value = 0;
+    renderFrame(0);
+  };
+  reader.readAsText(file);
 });
 
 document.addEventListener('keydown', e => {

--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
         <button id="saveBtn">Save PNG</button>
         <button id="clearBtn">Clear</button>
         <button id="centerBtn">Center</button>
+        <label>Import JSON: <input type="file" id="importJson" accept=".json"></label>
+        <button id="exportJsonBtn">Export JSON</button>
+        <div id="playbackControls">
+            <button id="playBtn">Play</button>
+            <input type="range" id="playbackRange" min="0" value="0" step="1">
+        </div>
     </div>
     <div id="canvasContainer">
         <img id="motif" style="display:none;" />


### PR DESCRIPTION
## Summary
- record each stroke on a small grid and play it back
- export strokes to JSON and import them later
- add playback controls with play button and slider

## Testing
- `node --check script.js`
- `node --check tmp_script.js` (temporary file extracted from docs)


------
https://chatgpt.com/codex/tasks/task_b_6854e91976a88322849da2f5212b32ee